### PR TITLE
feat: 검색어 이동시 배경색 변화

### DIFF
--- a/src/components/search/autoComplete/autoComplete.styles.ts
+++ b/src/components/search/autoComplete/autoComplete.styles.ts
@@ -1,17 +1,24 @@
 import styled from "styled-components";
 
-export const SuggestionKeywordWrapper = styled.li`
-  padding: 10px 0;
+interface Props {
+  isSelected: boolean;
+}
 
+export const SuggestionKeywordWrapper = styled.li<Props>`
+  padding: 10px 0;
   strong {
     font-weight: bold;
   }
-
   button {
     display: block;
     width: 100%;
     text-align: left;
   }
+
+  :hover {
+    background-color: #f7f7fb;
+  }
+  background-color: ${(props) => props.isSelected ? "#f7f7fb" : "none"}
 `;
 
 export const Bold = styled.span`

--- a/src/components/search/autoComplete/autoComplete.types.ts
+++ b/src/components/search/autoComplete/autoComplete.types.ts
@@ -7,4 +7,5 @@ export interface IAutoCompleteProps {
   onKeyUpSearchKeyword: (event: KeyboardEvent, name: string) => void;
   searchingValue: string | undefined;
   boldText: string;
+  currentNumber: number;
 }

--- a/src/components/search/autoComplete/index.tsx
+++ b/src/components/search/autoComplete/index.tsx
@@ -4,26 +4,32 @@ import { IAutoCompleteProps } from "./autoComplete.types";
 
 export default function AutoComplete(props: IAutoCompleteProps) {
   const dataLength = props.searchSuggestions.length;
-
   return (
     <>
       {props.searchSuggestions.map((keyword: { id: number; name: string }, index) => {
         const isKorean = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/.test(props.boldText);
-        const tempName = isKorean ? keyword.name.split(props.boldText) : keyword.name.split('');
-        const boldList = keyword.name.match(new RegExp(`${props.boldText}`, 'ig'))
+        const tempName = isKorean ? keyword.name.split(props.boldText) : keyword.name.split("");
+        const boldList = keyword.name.match(new RegExp(`${props.boldText}`, "ig"));
         const newName = tempName.map((char, idx) => {
-          if (isKorean && char === '') return <S.Bold key={idx}>{props.boldText}</S.Bold>;
-          if (!isKorean && boldList?.includes(char)) return <S.Bold key={idx}>{char}</S.Bold>
+          if (isKorean && char === "") return <S.Bold key={idx}>{props.boldText}</S.Bold>;
+          if (!isKorean && boldList?.includes(char)) return <S.Bold key={idx}>{char}</S.Bold>;
           return <S.NormalText key={idx}>{char}</S.NormalText>;
         });
 
         const isLastEl = index === dataLength - 1;
+        const isSelected =
+          props.currentNumber === -1 ||
+          props.searchSuggestions[props.currentNumber].id !== keyword.id
+            ? false
+            : true;
 
         return (
           <S.SuggestionKeywordWrapper
             key={keyword.id}
             onClick={() => props.onClickSearchKeyword(keyword.name)}
             onKeyUp={event => props.onKeyUpSearchKeyword(event, keyword.name)}
+            style={isSelected ? { background: "#f7f7fb" } : {}}
+            isSelected={isSelected}
           >
             <button className={isLastEl ? "search-res-last-el" : ""}>
               <SearchIcon color="#BABABA" viewBox="0 -10 26 26" size={26} />

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -43,6 +43,7 @@ export default function Search() {
     if (event.key === "Enter") {
       onClickSearchKeyword(keyword);
       setIsVisible(false);
+      alert(searchKeyword);
     }
 
     if (event.key === "ArrowUp") {
@@ -125,6 +126,7 @@ export default function Search() {
                 onKeyUpSearchKeyword={onKeyUpSearchKeyword}
                 searchingValue={searchRef?.current?.value}
                 boldText={boldText}
+                currentNumber={numberRef.current}
               />
             </ul>
           </>


### PR DESCRIPTION
### TODO

- [ ] 캐싱 관련 리팩토링: 캐시 스토리지만 사용할 수 있게 변경. expire time은 60000ms.
- [ ] 키보드 액션: Tab 키로도 검색어 이동이 가능하도록 변경.
- [ ] 디바운싱: custom hook으로 관리하도록 변경. 지연 시간은 300ms.
- [ ] UI: 현재 입력중인 검색어와 같은 부분은 Bold 처리.
- [ ] 제출 처리: 검색어나 검색 버튼 클릭했을 때 input에 값을 채워넣도록 변경.
- [ ] Icon: 라이브러리없이 SVG 사용.
- [ ] axios: 인스턴스를 사용하도록 변경.
