### PR TITLE
fix: 추천 검색어 클릭시 인풋이 추천 검색어로 바뀌지 않는 현상

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -46,6 +46,7 @@ export default function Search() {
 
     if (event.key === "Enter") {
       onClickSearchKeyword(keyword);
+      setSearchKeyword("");
       setIsVisible(false);
       alert(searchKeyword);
     }
@@ -81,10 +82,6 @@ export default function Search() {
       JSON.stringify([searchRef.current?.value, ...searchKeywordList])
     );
     setRecentSearches([searchRef.current?.value, ...searchKeywordList]);
-
-    if (searchRef.current !== null) {
-      searchRef.current.value = "";
-    }
     setSearchKeyword("");
   };
 
@@ -95,6 +92,7 @@ export default function Search() {
 
   const onClickClose = (event: React.MouseEvent<HTMLElement>) => {
     const target = event.target as HTMLElement;
+    console.info(target);
     const classListArr = Array.from(target.classList);
     if (classListArr.includes("hide-click")) setIsVisible(false);
   };
@@ -128,7 +126,7 @@ export default function Search() {
               {boldText}
             </S.SearchKeyword>
             <S.SuggestionTitle>추천 검색어</S.SuggestionTitle>
-            <ul>
+            <ul style={{ zIndex: 100 }}>
               <AutoComplete
                 searchSuggestions={searchSuggestions}
                 onClickSearchKeyword={onClickSearchKeyword}

--- a/src/components/search/searchbar/index.tsx
+++ b/src/components/search/searchbar/index.tsx
@@ -59,10 +59,14 @@ export default function SearchBar({
           }
         />
       </S.TextInputWrapper>
-      <S.SearchButton>
-        <span className="ir" onClick={onClickSubmitSearch}>
-          검색
-        </span>
+      <S.SearchButton
+        className="submit-btn"
+        onClick={() => {
+          onClickSubmitSearch();
+          if (searchRef.current) searchRef.current.value = "";
+        }}
+      >
+        <span className="ir">검색</span>
         <SearchIcon color="#FFFFFF" viewBox="-4 -5 24 24" size={28} />
       </S.SearchButton>
     </S.Container>


### PR DESCRIPTION
* 이유: 추천 검색어를 클릭하면 onClickSearchKeyword에서 onClickSubmitSearch를 호출하는데, 거기에 인풋을 초기화하는 코드가 있음
* 해결: 엔터키 눌렀을 때랑, 검색 버튼 눌렀을 때만 인풋 초기화하도록 코드를 바깥으로 뺌